### PR TITLE
doc: remove doc build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,31 +7,6 @@ The Zigbee R22 add-on for the nRF Connect SDK provides support for developing Zi
 ## Getting started
 To get started with Zigbee add-on for nRF Connect SDK, follow [documentation](https://docs.nordicsemi.com/bundle?cluster=true&exclude_metadata_filter.field=display-type&exclude_metadata_filter.value=inline&labelkey=addon-zigbee-r22&rpp=10&sort.field=last_uploaded&sort.value=desc).
 
-## Documentation
-Pre-build documentation is available [here](https://docs.nordicsemi.com/bundle?cluster=true&exclude_metadata_filter.field=display-type&exclude_metadata_filter.value=inline&labelkey=addon-zigbee-r22&rpp=10&sort.field=last_uploaded&sort.value=desc).
-
-A minimal documentation setup is provided for Sphinx. To build the
-documentation first change to the ``docs`` folder:
-
-```shell
-cd docs
-```
-To install Sphinx, make sure you have a Python installation in place and run:
-
-```shell
-pip install -r requirements.txt
-```
-
-The Sphinx documentation (HTML) can be built using the following command:
-
-```shell
-make html
-```
-
-The output will be stored in the ``_build_sphinx`` folder. You may check for
-other output formats other than HTML by running ``make help``.
-
-
 ##  License
 * Source code included within this repository is licensed under the [LicenseRef-Nordic-5-Clause](https://github.com/nrfconnect/ncs-zigbee-r22/blob/main/LICENSE)
 * Pre-compiled ZBOSS libraries (`lib/zboss`) included within this repository are licensed under the [DSR Corporation License](https://github.com/nrfconnect/ncs-zigbee-r22/blob/main/lib/zboss/license.txt)


### PR DESCRIPTION
Remove doc build instructions in README.md.

Signed-off-by: Michal Leksinski <michal.leksinski@nordicsemi.no>