### PR TITLE
samples: fix inverted error check in button handler

### DIFF
--- a/samples/light_switch/src/main.c
+++ b/samples/light_switch/src/main.c
@@ -538,8 +538,8 @@ static void light_switch_button_handler(struct k_timer *timer)
 		zb_err_code = zb_buf_get_out_delayed_ext(light_switch_send_step,
 							 cmd_id,
 							 0);
-		if (!zb_err_code) {
-			LOG_WRN("Buffer is full");
+		if (zb_err_code != RET_OK) {
+			LOG_ERR("Failed to schedule buffer allocation: %d", zb_err_code);
 		}
 
 		k_timer_start(&buttons_ctx.alarm, BUTTON_LONG_POLL_TMO,


### PR DESCRIPTION
Fix error checking for zb_buf_get_out_delayed_ext() which was logging 'Buffer is full' on success instead of failure.